### PR TITLE
Add requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+cvxpy>=1.1.10
+matplotlib>=3.3.4
+numpy>=1.20.1
+pandas>=1.2.3
+scipy>=1.6.0
+tqdm>=4.59.0
+
+# Uncomment to use the cross-validation in benchmark.py.
+# scikit-learn>=0.24.1


### PR DESCRIPTION
Scikit is commented to make sure that start.py runs without it.
However it is a needed requirement to run the cross-validation in
benchmark.py as authorized by Julien Mairal in the Kaggle
Discussion.